### PR TITLE
Add a timeout parameter on waitForApplicationLog NeonEventListener

### DIFF
--- a/common/changes/@cityofzion/neon-dappkit-types/add-application-timeout_2025-05-09-17-11.json
+++ b/common/changes/@cityofzion/neon-dappkit-types/add-application-timeout_2025-05-09-17-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cityofzion/neon-dappkit-types",
+      "comment": "Add a timeout optional parameter to waitForApplicationLog",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cityofzion/neon-dappkit-types"
+}

--- a/common/changes/@cityofzion/neon-dappkit/add-application-timeout_2025-05-09-17-11.json
+++ b/common/changes/@cityofzion/neon-dappkit/add-application-timeout_2025-05-09-17-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cityofzion/neon-dappkit",
+      "comment": "Add a timeout optional parameter to waitForApplicationLog, remove option from constructor and update neon-js",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cityofzion/neon-dappkit"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,9 +7,9 @@ importers:
 
   ../../packages/neon-dappkit:
     specifiers:
-      '@cityofzion/neon-core': 5.5.1
+      '@cityofzion/neon-core': 5.7.0
       '@cityofzion/neon-dappkit-types': workspace:*
-      '@cityofzion/neon-js': 5.5.1
+      '@cityofzion/neon-js': 5.7.0
       '@istanbuljs/nyc-config-typescript': ^1.0.2
       '@types/adm-zip': 0.5.5
       '@types/elliptic': 6.4.14
@@ -37,7 +37,7 @@ importers:
       typescript: ^4.3.2
     dependencies:
       '@cityofzion/neon-dappkit-types': link:../neon-dappkit-types
-      '@cityofzion/neon-js': 5.5.1
+      '@cityofzion/neon-js': 5.7.0
       crypto-browserify: 3.12.0
       crypto-js: 4.1.1
       elliptic: 6.5.4
@@ -46,7 +46,7 @@ importers:
       stream: 0.0.2
       stream-browserify: 3.0.0
     devDependencies:
-      '@cityofzion/neon-core': 5.5.1
+      '@cityofzion/neon-core': 5.7.0
       '@istanbuljs/nyc-config-typescript': 1.0.2_nyc@15.1.0
       '@types/adm-zip': 0.5.5
       '@types/elliptic': 6.4.14
@@ -284,36 +284,36 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@cityofzion/neon-api/5.4.0_s46ki5rtdlx2nsf6aojqhqzgjq:
-    resolution: {integrity: sha512-FHjdq2RnZLK37Hpd71yhVMkmbhl/iyPrmmAiEKb4mf5/rLtbNaKEEEJsxRkSNasio9+14cd7+BecIZ/35L1Sbg==}
+  /@cityofzion/neon-api/5.7.0_7uwowl6xccn6mtgdm3ovhcexve:
+    resolution: {integrity: sha512-tAXNSINlgAyGldDRGlFQeRwbiFuMqHyB2aPEvfyjzXfhYnjRiiiJOMV3JkejT5+T2iHT4NWX0pZb/V4l6JeYaQ==}
     peerDependencies:
-      '@cityofzion/neon-core': ^5.0.0
+      '@cityofzion/neon-core': ^5.6.0
     dependencies:
-      '@cityofzion/neon-core': 5.5.1
+      '@cityofzion/neon-core': 5.7.0
     dev: false
 
-  /@cityofzion/neon-core/5.5.1:
-    resolution: {integrity: sha512-cqJ+RYTdUVoUl2e3I5bqgAvYFuqGd2M8lmgUgH/+kf0zS0b8EuKwliauJ2EA56fudwaXtCmmHZTfRBFs+RJ2vw==}
+  /@cityofzion/neon-core/5.7.0:
+    resolution: {integrity: sha512-WuICUcnXeMxbzLe+wLIrKdNLqQ8vogK5g8IuAjPqfXmpMZ41Qn7LOH+hAyzTe6Xr8Sf5D/Vp2i46qqdgqa15Bg==}
     engines: {node: '>=16.19.0'}
     dependencies:
       bn.js: 5.2.1
-      bs58: 5.0.0
+      bs58: 6.0.0
       buffer: 6.0.3
-      cross-fetch: 3.1.8
-      crypto-js: 4.1.1
-      elliptic: 6.5.4
-      ethereum-cryptography: 2.0.0
+      cross-fetch: 4.1.0
+      crypto-js: 4.2.0
+      elliptic: 6.6.1
+      ethereum-cryptography: 3.0.0
       lodash: 4.17.21
-      loglevel: 1.8.1
+      loglevel: 1.9.2
       loglevel-plugin-prefix: 0.8.4
     transitivePeerDependencies:
       - encoding
 
-  /@cityofzion/neon-js/5.5.1:
-    resolution: {integrity: sha512-iCoE5PGKy3Kj36dR3aevkVOKK4yB1Mq/0WEUQzrzMkGOGBNJXa2+cTtmSi39tDkgxSHibvS77S5oZ6QGIXMCdg==}
+  /@cityofzion/neon-js/5.7.0:
+    resolution: {integrity: sha512-jYl2Y6raBP/HAbM5ukcPXSjbrrpCkJiknjQCUenuJqC8HjRcLjkH4yIhxcKmKBgqdWca0doFLxsHnfZs2IqngQ==}
     dependencies:
-      '@cityofzion/neon-api': 5.4.0_s46ki5rtdlx2nsf6aojqhqzgjq
-      '@cityofzion/neon-core': 5.5.1
+      '@cityofzion/neon-api': 5.7.0_7uwowl6xccn6mtgdm3ovhcexve
+      '@cityofzion/neon-core': 5.7.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -471,13 +471,19 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@noble/curves/1.0.0:
-    resolution: {integrity: sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==}
-    dependencies:
-      '@noble/hashes': 1.3.0
+  /@noble/ciphers/1.0.0:
+    resolution: {integrity: sha512-wH5EHOmLi0rEazphPbecAzmjd12I6/Yv/SiHdkA9LSycsQk7RuuTp7am5/o62qYr0RScE7Pc9icXGBbsr6cesA==}
+    engines: {node: ^14.21.3 || >=16}
 
-  /@noble/hashes/1.3.0:
-    resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
+  /@noble/curves/1.6.0:
+    resolution: {integrity: sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==}
+    engines: {node: ^14.21.3 || >=16}
+    dependencies:
+      '@noble/hashes': 1.5.0
+
+  /@noble/hashes/1.5.0:
+    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -500,21 +506,21 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@scure/base/1.1.3:
-    resolution: {integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==}
+  /@scure/base/1.1.9:
+    resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
-  /@scure/bip32/1.3.0:
-    resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
+  /@scure/bip32/1.5.0:
+    resolution: {integrity: sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==}
     dependencies:
-      '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
-      '@scure/base': 1.1.3
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.9
 
-  /@scure/bip39/1.2.0:
-    resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
+  /@scure/bip39/1.4.0:
+    resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
     dependencies:
-      '@noble/hashes': 1.3.0
-      '@scure/base': 1.1.3
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.9
 
   /@sinclair/typebox/0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -890,8 +896,8 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
-  /base-x/4.0.0:
-    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
+  /base-x/5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -994,10 +1000,10 @@ packages:
       update-browserslist-db: 1.0.13_browserslist@4.22.1
     dev: true
 
-  /bs58/5.0.0:
-    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+  /bs58/6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
     dependencies:
-      base-x: 4.0.0
+      base-x: 5.0.1
 
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1195,8 +1201,8 @@ packages:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
 
-  /cross-fetch/3.1.8:
-    resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
+  /cross-fetch/4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
     dependencies:
       node-fetch: 2.7.0
     transitivePeerDependencies:
@@ -1229,6 +1235,10 @@ packages:
 
   /crypto-js/4.1.1:
     resolution: {integrity: sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==}
+    dev: false
+
+  /crypto-js/4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   /debug/4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1338,6 +1348,18 @@ packages:
 
   /elliptic/6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
+    dependencies:
+      bn.js: 4.12.0
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
+
+  /elliptic/6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
     dependencies:
       bn.js: 4.12.0
       brorand: 1.1.0
@@ -1477,13 +1499,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /ethereum-cryptography/2.0.0:
-    resolution: {integrity: sha512-g25m4EtfQGjstWgVE1aIz7XYYjf3kH5kG17ULWVB5dH6uLahsoltOhACzSxyDV+fhn4gbR4xRrOXGe6r2uh4Bg==}
+  /ethereum-cryptography/3.0.0:
+    resolution: {integrity: sha512-Ij7U9OgVZc4MAui8BttPCEaWUrAXy+eo2IbVfIxZyfzfFxMQrbIWXRUbrsRBqRrIhJ75T8P+KQRKpKTaG0Du8Q==}
+    engines: {node: ^14.21.3 || >=16, npm: '>=9'}
     dependencies:
-      '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
-      '@scure/bip32': 1.3.0
-      '@scure/bip39': 1.2.0
+      '@noble/ciphers': 1.0.0
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
 
   /event-target-shim/5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -2088,8 +2112,8 @@ packages:
   /loglevel-plugin-prefix/0.8.4:
     resolution: {integrity: sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==}
 
-  /loglevel/1.8.1:
-    resolution: {integrity: sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==}
+  /loglevel/1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
 
   /loupe/2.3.7:

--- a/packages/neon-dappkit-types/src/Neo3EventListener.ts
+++ b/packages/neon-dappkit-types/src/Neo3EventListener.ts
@@ -63,8 +63,9 @@ export interface Neo3EventListener {
   /**
    * Waits for the transaction to be completed and returns the application log
    * @param txId id od the transaction
+   * @param timeout the timeout in milliseconds
    */
-  waitForApplicationLog(txId: string): Promise<Neo3ApplicationLog>
+  waitForApplicationLog(txId: string, timeout?: number): Promise<Neo3ApplicationLog>
 
   /**
    * Checks if the transaction was completed successfully

--- a/packages/neon-dappkit/package.json
+++ b/packages/neon-dappkit/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cityofzion/neon-dappkit-types": "workspace:*",
-    "@cityofzion/neon-js": "5.5.1",
+    "@cityofzion/neon-js": "5.7.0",
     "crypto-js": "^4.1.1",
     "elliptic": "^6.5.4",
     "randombytes": "^2.1.0",
@@ -27,7 +27,7 @@
     "crypto-browserify": "^3.12.0"
   },
   "devDependencies": {
-    "@cityofzion/neon-core": "5.5.1",
+    "@cityofzion/neon-core": "5.7.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/adm-zip": "0.5.5",
     "@types/elliptic": "6.4.14",

--- a/packages/neon-dappkit/test/NeonEventListener.spec.ts
+++ b/packages/neon-dappkit/test/NeonEventListener.spec.ts
@@ -314,11 +314,7 @@ describe('NeonEventListener', function () {
     const neoInvoker = await NeonInvoker.init({ rpcAddress, account: sender })
     const txId = await neoInvoker.invokeFunction(gasTransferInvocation(sender, receiver, '100'))
 
-    const fastEventListener = new NeonEventListener(rpcAddress, {
-      waitForApplicationLog: { maxAttempts: 1, waitMs: 10 },
-    })
-
-    await assert.rejects(fastEventListener.waitForApplicationLog(txId))
+    await assert.rejects(eventListener.waitForApplicationLog(txId, 1))
   })
 
   it('confirms Halt', async () => {

--- a/packages/neon-dappkit/test/NeonParser.spec.ts
+++ b/packages/neon-dappkit/test/NeonParser.spec.ts
@@ -178,8 +178,7 @@ describe('NeonParser', function () {
     assert.equal(NeonParser.strToHex(str), hexString)
   })
 
-  // Currently neon-core's utf82base64 method is bugged, but will be fixed on the next patch release
-  it.skip('converts a utf-8 string into a base64 string', async () => {
+  it('converts a utf-8 string into a base64 string', async () => {
     let utf8String = 'unit test'
     let base64String = 'dW5pdCB0ZXN0'
     assert.equal(NeonParser.utf8ToBase64(utf8String), base64String)


### PR DESCRIPTION
- Add a timeout optional parameter to `waitForApplicationLog`
  - remove option from constructor to control how long `waitForApplicationLog` should wait for
- update neon-js so that NeonParser can do `utf8ToBase64` again