### PR TITLE
ci: split reporting from test

### DIFF
--- a/.github/workflows/check-build-and-test.yml
+++ b/.github/workflows/check-build-and-test.yml
@@ -1,4 +1,8 @@
 name: 'Check Build and Test'
+
+permissions:
+  pull-requests: write
+  checks: write
 on:
   pull_request:
     branches:
@@ -9,14 +13,12 @@ env:
 
 jobs:
   build-and-test:
-    permissions:
-      checks: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 10
       - name: Setup Node Version ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/check-build-and-test.yml
+++ b/.github/workflows/check-build-and-test.yml
@@ -1,4 +1,4 @@
-name: Check Build and Test
+name: 'Check Build and Test'
 on:
   pull_request:
     branches:
@@ -33,14 +33,11 @@ jobs:
         run: rush rebuild --verbose
       - name: Run Tests
         run: cd packages/neon-dappkit && pnpm test
-      - name: Notify Test Reporter
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        uses: dorny/test-reporter@v1.6.0
         with:
-          name: Unit Tests
-          reporter: mocha-json
+          name: test-results
           path: mocha-results.json
-          fail-on-error: true
       - name: Check Code Coverage
         continue-on-error: true
         working-directory: ./packages/neon-dappkit/

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,20 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Check Build and Test']
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v2
+        with:
+          artifact: test-results
+          name: Unit Tests
+          path: 'mocha-results.json'
+          reporter: mocha-json


### PR DESCRIPTION
close #43 

As per dorny/testreporter readme ([ref](https://github.com/dorny/test-reporter?tab=readme-ov-file#recommended-setup-for-public-repositories)); 
> Workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs. To workaround this security restriction, it's required to use two separate workflows:

This splits the workflows