### PR TITLE
ci: split code coverage

### DIFF
--- a/.github/workflows/check-build-and-test.yml
+++ b/.github/workflows/check-build-and-test.yml
@@ -1,7 +1,6 @@
 name: 'Check Build and Test'
 
 permissions:
-  pull-requests: write
   checks: write
 on:
   pull_request:
@@ -44,8 +43,8 @@ jobs:
         continue-on-error: true
         working-directory: ./packages/neon-dappkit/
         run: pnpm coverage
-      - name: Notify Code Coverage
-        uses: sidx1024/report-nyc-coverage-github-action@v1.2.7
+      - name: Upload Coverage Summary
+        uses: actions/upload-artifact@v4
         with:
-          coverage_file: './packages/neon-dappkit/reporter/coverage-summary.json'
-          comment_template_file: '.github/comment-template.md'
+          name: coverage-summary
+          path: packages/neon-dappkit/coverage/coverage-summary.json

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,4 +1,4 @@
-name: 'Test Report'
+name: 'Test and Coverage Report'
 on:
   workflow_run:
     workflows: ['Check Build and Test']
@@ -8,6 +8,7 @@ permissions:
   contents: read
   actions: read
   checks: write
+  pull-requests: write
 jobs:
   report:
     runs-on: ubuntu-latest
@@ -18,3 +19,13 @@ jobs:
           name: Unit Tests
           path: 'mocha-results.json'
           reporter: mocha-json
+      - name: Download Coverage Summary Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-summary
+          path: ./artifacts/coverage
+      - name: Notify Code Coverage
+        uses: sidx1024/report-nyc-coverage-github-action@v1.2.7
+        with:
+          coverage_file: './artifacts/coverage/coverage-summary.json'
+          comment_template_file: '.github/comment-template.md'


### PR DESCRIPTION
similar to #44 

It coverage reporting [worked](https://github.com/CityOfZion/neon-dappkit/pull/44#issuecomment-2872245549) in #44 but then it doesn't work in #42. I expect the same reason because of permissions and the fact that #42 is a PR from a fork whereas #44 was a PR from the repo itself. 