### PR TITLE
streamline stack item types in Neo3EventListener

### DIFF
--- a/common/changes/@cityofzion/neon-dappkit-types/streamline-eventlistener_2025-10-06-15-49.json
+++ b/common/changes/@cityofzion/neon-dappkit-types/streamline-eventlistener_2025-10-06-15-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cityofzion/neon-dappkit-types",
+      "comment": "streamline stack item and notification types in Neo3EventListener",
+      "type": "major"
+    }
+  ],
+  "packageName": "@cityofzion/neon-dappkit-types"
+}

--- a/common/changes/@cityofzion/neon-dappkit/streamline-eventlistener_2025-10-06-15-49.json
+++ b/common/changes/@cityofzion/neon-dappkit/streamline-eventlistener_2025-10-06-15-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cityofzion/neon-dappkit",
+      "comment": "upate to use latest type changes",
+      "type": "major"
+    }
+  ],
+  "packageName": "@cityofzion/neon-dappkit"
+}

--- a/common/changes/@cityofzion/neon-dappkit/streamline-eventlistener_2025-10-06-15-49.json
+++ b/common/changes/@cityofzion/neon-dappkit/streamline-eventlistener_2025-10-06-15-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cityofzion/neon-dappkit",
-      "comment": "upate to use latest type changes",
+      "comment": "update to use latest type changes",
       "type": "major"
     }
   ],

--- a/packages/neon-dappkit-types/src/Neo3EventListener.ts
+++ b/packages/neon-dappkit-types/src/Neo3EventListener.ts
@@ -1,3 +1,5 @@
+import {InvokeBase, Notification} from "./Neo3Invoker";
+
 /**
  * An interface that defines the event contract and event name
  */
@@ -7,23 +9,15 @@ export interface Neo3Event {
 }
 
 /**
- * An interface that defines the event contract, event name and the state of the event
- */
-export interface Neo3EventWithState extends Neo3Event {
-  state: Neo3StackItem
-}
-
-/**
  * The event listener callback
  */
-export type Neo3EventListenerCallback = (event: Neo3EventWithState) => void
+export type Neo3EventListenerCallback = (event: Notification) => void
 
 /**
- * An interface that defines the stack item format
+ * An interface that defines an application execution format
  */
-export interface Neo3StackItem {
-  type: string
-  value?: string | boolean | number | Neo3StackItem[]
+export interface ApplicationExecution extends InvokeBase {
+    trigger: string
 }
 
 /**
@@ -31,13 +25,7 @@ export interface Neo3StackItem {
  */
 export interface Neo3ApplicationLog {
   txid: string
-  executions: {
-    trigger: string
-    vmstate: string
-    gasconsumed: string
-    stack?: Neo3StackItem[]
-    notifications: Neo3EventWithState[]
-  }[]
+  executions: ApplicationExecution[]
 }
 
 /**

--- a/packages/neon-dappkit-types/src/Neo3EventListener.ts
+++ b/packages/neon-dappkit-types/src/Neo3EventListener.ts
@@ -1,4 +1,4 @@
-import {InvokeBase, Notification} from "./Neo3Invoker";
+import { InvokeBase, Notification } from './Neo3Invoker'
 
 /**
  * An interface that defines the event contract and event name
@@ -17,7 +17,7 @@ export type Neo3EventListenerCallback = (event: Notification) => void
  * An interface that defines an application execution format
  */
 export interface ApplicationExecution extends InvokeBase {
-    trigger: string
+  trigger: string
 }
 
 /**

--- a/packages/neon-dappkit-types/src/Neo3Invoker.ts
+++ b/packages/neon-dappkit-types/src/Neo3Invoker.ts
@@ -191,7 +191,7 @@ export type BuiltTransaction = ContractInvocationMulti & {
 export type ArrayResponseArgType = { type: 'Array'; value: RpcResponseStackItem[] }
 export type MapResponseArgType = { type: 'Map'; value: { key: RpcResponseStackItem; value: RpcResponseStackItem }[] }
 export type ByteStringArgType = { type: 'ByteString'; value: string }
-export type InteropInterfaceArgType = { type: 'InteropInterface'; interface: string; id: string, value?: never }
+export type InteropInterfaceArgType = { type: 'InteropInterface'; interface: string; id: string; value?: never }
 export type PointerArgType = { type: 'Pointer'; value: string }
 export type BufferArgType = { type: 'Buffer'; value: string }
 export type StructArgType = { type: 'Struct'; value: RpcResponseStackItem[] }
@@ -209,27 +209,27 @@ export type RpcResponseStackItem =
   | StructArgType
 
 export interface Notification {
-    /** hash of the smart contract that emitted the notification */
-    contract: string
-    /** name of the notification */
-    eventname: string
-    /** the emitted notification contents */
-    state: RpcResponseStackItem
+  /** hash of the smart contract that emitted the notification */
+  contract: string
+  /** name of the notification */
+  eventname: string
+  /** the emitted notification contents */
+  state: RpcResponseStackItem
 }
 
-export interface InvokeBase <T extends RpcResponseStackItem = RpcResponseStackItem> {
-    /** State of VM on exit. HALT means a successful exit while FAULT means exit with error. */
-    state: 'HALT' | 'FAULT'
-    /** Amount of gas consumed up to the point of stopping in the VM. If state is FAULT, this value is not representative of the amount of gas it will consume if it somehow succeeds on the blockchain.
-     * This is a decimal value.
-     */
-    gasconsumed: string
-    /** A human-readable string clarifying the exception that occurred. Only available when state is "FAULT". */
-    exception: string | null
-    /** Result stack of the VM. */
-    stack: T[]
-    /** Notifications emitted by the smart contract. */
-    notifications: Notification[]
+export interface InvokeBase<T extends RpcResponseStackItem = RpcResponseStackItem> {
+  /** State of VM on exit. HALT means a successful exit while FAULT means exit with error. */
+  state: 'HALT' | 'FAULT'
+  /** Amount of gas consumed up to the point of stopping in the VM. If state is FAULT, this value is not representative of the amount of gas it will consume if it somehow succeeds on the blockchain.
+   * This is a decimal value.
+   */
+  gasconsumed: string
+  /** A human-readable string clarifying the exception that occurred. Only available when state is "FAULT". */
+  exception: string | null
+  /** Result stack of the VM. */
+  stack: T[]
+  /** Notifications emitted by the smart contract. */
+  notifications: Notification[]
 }
 
 /**

--- a/packages/neon-dappkit-types/src/Neo3Invoker.ts
+++ b/packages/neon-dappkit-types/src/Neo3Invoker.ts
@@ -191,7 +191,7 @@ export type BuiltTransaction = ContractInvocationMulti & {
 export type ArrayResponseArgType = { type: 'Array'; value: RpcResponseStackItem[] }
 export type MapResponseArgType = { type: 'Map'; value: { key: RpcResponseStackItem; value: RpcResponseStackItem }[] }
 export type ByteStringArgType = { type: 'ByteString'; value: string }
-export type InteropInterfaceArgType = { type: 'InteropInterface'; interface: string; id: string }
+export type InteropInterfaceArgType = { type: 'InteropInterface'; interface: string; id: string, value?: never }
 export type PointerArgType = { type: 'Pointer'; value: string }
 export type BufferArgType = { type: 'Buffer'; value: string }
 export type StructArgType = { type: 'Struct'; value: RpcResponseStackItem[] }
@@ -208,21 +208,36 @@ export type RpcResponseStackItem =
   | BufferArgType
   | StructArgType
 
+export interface Notification {
+    /** hash of the smart contract that emitted the notification */
+    contract: string
+    /** name of the notification */
+    eventname: string
+    /** the emitted notification contents */
+    state: RpcResponseStackItem
+}
+
+export interface InvokeBase <T extends RpcResponseStackItem = RpcResponseStackItem> {
+    /** State of VM on exit. HALT means a successful exit while FAULT means exit with error. */
+    state: 'HALT' | 'FAULT'
+    /** Amount of gas consumed up to the point of stopping in the VM. If state is FAULT, this value is not representative of the amount of gas it will consume if it somehow succeeds on the blockchain.
+     * This is a decimal value.
+     */
+    gasconsumed: string
+    /** A human-readable string clarifying the exception that occurred. Only available when state is "FAULT". */
+    exception: string | null
+    /** Result stack of the VM. */
+    stack: T[]
+    /** Notifications emitted by the smart contract. */
+    notifications: Notification[]
+}
+
 /**
  * Result from calling invokescript or invokefunction.
  */
-export interface InvokeResult<T extends RpcResponseStackItem = RpcResponseStackItem> {
+export interface InvokeResult extends InvokeBase {
   /** The script that is sent for execution on the blockchain as a base64 string. */
   script: string
-  /** State of VM on exit. HALT means a successful exit while FAULT means exit with error. */
-  state: 'HALT' | 'FAULT'
-  /** Amount of gas consumed up to the point of stopping in the VM. If state is FAULT, this value is not representative of the amount of gas it will consume if it somehow succeeds on the blockchain.
-   * This is a decimal value.
-   */
-  gasconsumed: string
-  /** A human-readable string clarifying the exception that occurred. Only available when state is "FAULT". */
-  exception: string | null
-  stack: T[]
   /** A ready to send transaction that wraps the script.
    * Only available when signers are provided and the sender's private key is open in the RPC node.
    * Formatted in base64-encoding.

--- a/packages/neon-dappkit/src/NeonEventListener.ts
+++ b/packages/neon-dappkit/src/NeonEventListener.ts
@@ -134,11 +134,7 @@ export class NeonEventListener implements Neo3EventListener {
 
   getNotificationState(txResult: Neo3ApplicationLog, eventToCheck: Neo3Event): Notification | undefined {
     return txResult?.executions[0].notifications.find((e) => {
-        if (e.contract === eventToCheck.contract && e.eventname === eventToCheck.eventname) {
-            return e
-        }
-        return undefined
-    })
+        return e.contract === eventToCheck.contract && e.eventname === eventToCheck.eventname })
   }
 
   confirmTransaction(

--- a/packages/neon-dappkit/src/NeonEventListener.ts
+++ b/packages/neon-dappkit/src/NeonEventListener.ts
@@ -1,12 +1,12 @@
 import {
-    ApplicationExecution,
-    Neo3ApplicationLog,
-    Neo3Event,
-    Neo3EventListener,
-    Neo3EventListenerCallback,
-    Notification,
-    RpcResponseStackItem,
-    TypeChecker
+  ApplicationExecution,
+  Neo3ApplicationLog,
+  Neo3Event,
+  Neo3EventListener,
+  Neo3EventListenerCallback,
+  Notification,
+  RpcResponseStackItem,
+  TypeChecker,
 } from '@cityofzion/neon-dappkit-types'
 import { rpc } from '@cityofzion/neon-js'
 import type * as NeonTypes from '@cityofzion/neon-core'
@@ -125,7 +125,7 @@ export class NeonEventListener implements Neo3EventListener {
     ) {
       throw new Error('Transaction failed. No stack found in transaction result')
     }
-    const stack  = txResult.executions[0].stack[0]
+    const stack = txResult.executions[0].stack[0]
 
     if (!TypeChecker.isStackTypeBoolean(stack) || stack.value !== true) {
       throw new Error('Transaction failed. Stack value is not true')
@@ -134,7 +134,8 @@ export class NeonEventListener implements Neo3EventListener {
 
   getNotificationState(txResult: Neo3ApplicationLog, eventToCheck: Neo3Event): Notification | undefined {
     return txResult?.executions[0].notifications.find((e) => {
-        return e.contract === eventToCheck.contract && e.eventname === eventToCheck.eventname })
+      return e.contract === eventToCheck.contract && e.eventname === eventToCheck.eventname
+    })
   }
 
   confirmTransaction(
@@ -217,27 +218,26 @@ export class NeonEventListener implements Neo3EventListener {
   }
 
   private neonApplogToNeo3ApplicationLog(log: NeonTypes.rpc.ApplicationLogJson): Neo3ApplicationLog {
-      const executions = log.executions.map(execution => {
-          return {
-              trigger: execution.trigger,
-              state: execution.vmstate,
-              gasconsumed: execution.gasconsumed,
-              stack: execution.stack.map(si => {
-                  return {type: si.type, value: si.value} as RpcResponseStackItem
-              }),
-              notifications: execution.notifications.map(notification => {
-                  return {
-                      contract: notification.contract,
-                      eventname: notification.eventname,
-                      state: {type: notification.state.type, value: notification.state.value}
-                  } as Notification
-              })
-          } as ApplicationExecution
-      })
+    const executions = log.executions.map((execution) => {
       return {
-          txid: log.txid,
-          executions
-      } as Neo3ApplicationLog
+        trigger: execution.trigger,
+        state: execution.vmstate,
+        gasconsumed: execution.gasconsumed,
+        stack: execution.stack.map((si) => {
+          return { type: si.type, value: si.value } as RpcResponseStackItem
+        }),
+        notifications: execution.notifications.map((notification) => {
+          return {
+            contract: notification.contract,
+            eventname: notification.eventname,
+            state: { type: notification.state.type, value: notification.state.value },
+          } as Notification
+        }),
+      } as ApplicationExecution
+    })
+    return {
+      txid: log.txid,
+      executions,
+    } as Neo3ApplicationLog
   }
-
 }

--- a/packages/neon-dappkit/src/NeonInvoker.ts
+++ b/packages/neon-dappkit/src/NeonInvoker.ts
@@ -41,7 +41,8 @@ export class NeonInvoker implements Neo3Invoker {
     )
     if (rpcResult.state === 'FAULT') throw Error(`Execution state is FAULT. Exception: ${rpcResult.exception}`)
 
-    return { ...rpcResult, stack: rpcResult.stack as RpcResponseStackItem[] }
+    // TODO: set actual notifications. Currently not supported in neon-js
+    return { ...rpcResult, stack: rpcResult.stack as RpcResponseStackItem[], notifications: [] }
   }
 
   async invokeFunction(cimOrBt: ContractInvocationMulti | BuiltTransaction): Promise<string> {

--- a/packages/neon-dappkit/test/NeonEventListener.spec.ts
+++ b/packages/neon-dappkit/test/NeonEventListener.spec.ts
@@ -2,11 +2,11 @@ import { ChildProcess, spawn } from 'child_process'
 import { NeonEventListener, NeonInvoker, NeonParser } from '../src'
 import assert from 'assert'
 import {
-    ContractInvocationMulti,
-    Neo3ApplicationLog,
-    Neo3EventListenerCallback,
-    Notification,
-    TypeChecker,
+  ContractInvocationMulti,
+  Neo3ApplicationLog,
+  Neo3EventListenerCallback,
+  Notification,
+  TypeChecker,
 } from '@cityofzion/neon-dappkit-types'
 import { wallet } from '@cityofzion/neon-core'
 import {
@@ -337,8 +337,8 @@ describe('NeonEventListener', function () {
           state: 'FAULT',
           gasconsumed: '0',
           notifications: [],
-          exception:"",
-          stack: []
+          exception: '',
+          stack: [],
         },
       ],
     }

--- a/packages/neon-dappkit/test/NeonEventListener.spec.ts
+++ b/packages/neon-dappkit/test/NeonEventListener.spec.ts
@@ -1,12 +1,12 @@
 import { ChildProcess, spawn } from 'child_process'
-import { NeonEventListener, NeonInvoker, NeonParser } from '../src/index'
+import { NeonEventListener, NeonInvoker, NeonParser } from '../src'
 import assert from 'assert'
 import {
-  ContractInvocationMulti,
-  Neo3ApplicationLog,
-  Neo3EventListenerCallback,
-  Neo3EventWithState,
-  TypeChecker,
+    ContractInvocationMulti,
+    Neo3ApplicationLog,
+    Neo3EventListenerCallback,
+    Notification,
+    TypeChecker,
 } from '@cityofzion/neon-dappkit-types'
 import { wallet } from '@cityofzion/neon-core'
 import {
@@ -65,8 +65,8 @@ describe('NeonEventListener', function () {
   it('adds an eventListener', async () => {
     const eventName = 'Transfer'
 
-    const eventPromise = new Promise<Neo3EventWithState>((resolve) => {
-      const callBack = (notification: Neo3EventWithState) => {
+    const eventPromise = new Promise<Notification>((resolve) => {
+      const callBack = (notification: Notification) => {
         resolve(notification)
 
         eventListener.removeAllEventListenersOfEvent(gasScriptHash, eventName)
@@ -94,8 +94,8 @@ describe('NeonEventListener', function () {
   it('adds eventListeners on the same event', async () => {
     const eventName = 'Transfer'
 
-    const eventPromise1 = new Promise<Neo3EventWithState>((resolve) => {
-      const callBack1 = (notification: Neo3EventWithState) => {
+    const eventPromise1 = new Promise<Notification>((resolve) => {
+      const callBack1 = (notification: Notification) => {
         resolve(notification)
 
         eventListener.removeAllEventListenersOfEvent(gasScriptHash, eventName)
@@ -104,8 +104,8 @@ describe('NeonEventListener', function () {
       eventListener.addEventListener(gasScriptHash, eventName, callBack1)
     })
 
-    const eventPromise2 = new Promise<Neo3EventWithState>((resolve) => {
-      const callBack2 = (notification: Neo3EventWithState) => {
+    const eventPromise2 = new Promise<Notification>((resolve) => {
+      const callBack2 = (notification: Notification) => {
         resolve(notification)
 
         eventListener.removeAllEventListenersOfEvent(gasScriptHash, eventName)
@@ -166,7 +166,7 @@ describe('NeonEventListener', function () {
   it('adds eventListener that callback throws an error', async () => {
     const eventName = 'Transfer'
 
-    const eventPromise = new Promise<Neo3EventWithState>((resolve, reject) => {
+    const eventPromise = new Promise<Notification>((resolve, reject) => {
       const callBack = () => {
         reject('Error')
         eventListener.removeAllEventListenersOfEvent(gasScriptHash, eventName)
@@ -191,7 +191,7 @@ describe('NeonEventListener', function () {
     const eventName = 'Transfer'
     let called = 0
 
-    const callBack: Neo3EventListenerCallback = (notification: Neo3EventWithState) => {
+    const callBack: Neo3EventListenerCallback = (notification: Notification) => {
       assert(notification)
       called += 1
     }
@@ -221,7 +221,7 @@ describe('NeonEventListener', function () {
     const eventName = 'Transfer'
     let called = 0
 
-    const callBack: Neo3EventListenerCallback = (notification: Neo3EventWithState) => {
+    const callBack: Neo3EventListenerCallback = (notification: Notification) => {
       assert(notification)
       called += 1
     }
@@ -251,7 +251,7 @@ describe('NeonEventListener', function () {
     const eventName = 'Transfer'
     let called = 0
 
-    const callBack: Neo3EventListenerCallback = (notification: Neo3EventWithState) => {
+    const callBack: Neo3EventListenerCallback = (notification: Notification) => {
       assert(notification)
       called += 1
     }
@@ -289,7 +289,7 @@ describe('NeonEventListener', function () {
     assert(applicationLog.txid === txId, 'Transaction ID should be the same')
     assert(applicationLog.executions.length === 1, 'There should be one execution')
     assert(applicationLog.executions[0].trigger === 'Application', 'Trigger should be Application')
-    assert(applicationLog.executions[0].vmstate === 'HALT', 'VMState should be HALT')
+    assert(applicationLog.executions[0].state === 'HALT', 'VMState should be HALT')
     assert(applicationLog.executions[0].gasconsumed !== undefined, 'Gas consumed should be returned')
     assert(applicationLog.executions[0].stack.length === 1, 'Stack should be returned')
     assert(applicationLog.executions[0].stack[0].type === 'Boolean', 'Stack type should be a boolean')
@@ -334,9 +334,11 @@ describe('NeonEventListener', function () {
       executions: [
         {
           trigger: 'Application',
-          vmstate: 'FAULT',
+          state: 'FAULT',
           gasconsumed: '0',
           notifications: [],
+          exception:"",
+          stack: []
         },
       ],
     }

--- a/packages/neon-dappkit/test/NeonInvoker.spec.ts
+++ b/packages/neon-dappkit/test/NeonInvoker.spec.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn, execSync } from 'child_process'
 import { ContractInvocationMulti } from '@cityofzion/neon-dappkit-types'
-import { NeonEventListener, NeonInvoker, NeonParser, TypeChecker } from '../src/index'
+import { NeonEventListener, NeonInvoker, NeonParser, TypeChecker } from '../src'
 import assert from 'assert'
 import * as path from 'path'
 import { tx, u } from '@cityofzion/neon-js'


### PR DESCRIPTION
It started by realizing I could not do
```ts
import {NeonEventListener, NeonParser} from '@cityofzion/neon-dappkit'
...
const txid ='0x2a538a9651056b632625a253406ab554459c6d5e83bf341c7eb2ab66e216d3a6'
const eventListener = new NeonEventListener('https://mainnet1.neo.coz.io:443')
const log = await eventListener.waitForApplicationLog(txid)
NeonParser.parseRpcResponse(log.executions[0].stack![0])
```
but I had to use
```ts
NeonParser.parseRpcResponse(log.executions[0].stack![0] as RpcResponseStackItem)
```

Which made no sense to me as there is only one stack item in the VM.

Upon closer inspection I realized that `Neo3EventListener` had it's own stack item interface (`Neo3StackItem`) where `Neo3Parser`, `Neo3Invoker` and `TypeChecker` all use `RpcResponseStackItem`. I visualized that state below

<img width="975" height="1107" alt="image" src="https://github.com/user-attachments/assets/2a79a69a-e2cf-4147-9eaa-6fff38df8434" />

Note that `InvokeResult` is also missing `notifications[]` and the `Neo3ApplicationLog` is missing the `exception` field. 

This PR addresses the issue by ensuring that `Neo3EventListener` uses the same stack item and notification types as elsewhere. Specifically as shown in the image below

<img width="974" height="858" alt="image" src="https://github.com/user-attachments/assets/d23e13f5-2f3b-4a79-96a3-5c593a4d8c97" />

Arguably we could move `notifications` from `InvokeBase` to just `ApplicationExecution` because atm `neon-js` (which is used internally when doing an invoke) doesn't return the notifications for `testinvoke` and `testscript` calls. However, I'd rather update `neon-js` and have this already in the right place instead.