### PR TITLE
Add Lint to CI

### DIFF
--- a/.github/workflows/check-build-and-test.yml
+++ b/.github/workflows/check-build-and-test.yml
@@ -22,16 +22,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install PNPM
-        run: npm install -g pnpm
-      - name: Install RushJS
-        run: npm install -g @microsoft/rush
       - name: Verify Change Logs
-        run: rush change --verify
+        run: node common/scripts/install-run-rush.js change --verify
       - name: Install Dependencies
-        run: rush update
+        run: node common/scripts/install-run-rush.js install
       - name: Build Projects
-        run: rush rebuild --verbose
+        run: node common/scripts/install-run-rush.js rebuild --verbose
+      - name: Find Lint Issues
+        run: node common/scripts/install-run-rush.js lint
       - name: Run Tests
         run: cd packages/neon-dappkit && pnpm test
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/check-build-and-test.yml
+++ b/.github/workflows/check-build-and-test.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Find Lint Issues
         run: node common/scripts/install-run-rush.js lint
       - name: Run Tests
-        run: cd packages/neon-dappkit && pnpm test
+        working-directory: ./packages/neon-dappkit/
+        run: node ../../common/scripts/install-run-rushx.js test
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
@@ -40,7 +41,7 @@ jobs:
       - name: Check Code Coverage
         continue-on-error: true
         working-directory: ./packages/neon-dappkit/
-        run: pnpm coverage
+        run: node ../../common/scripts/install-run-rushx.js coverage
       - name: Upload Coverage Summary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check-build-and-test.yml
+++ b/.github/workflows/check-build-and-test.yml
@@ -22,17 +22,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Install PNPM
+        run: npm install -g pnpm
+      - name: Install RushJS
+        run: npm install -g @microsoft/rush
       - name: Verify Change Logs
-        run: node common/scripts/install-run-rush.js change --verify
+        run: rush change --verify
       - name: Install Dependencies
-        run: node common/scripts/install-run-rush.js install
+        run: rush update
       - name: Build Projects
-        run: node common/scripts/install-run-rush.js rebuild --verbose
+        run: rush rebuild --verbose
       - name: Find Lint Issues
-        run: node common/scripts/install-run-rush.js lint
+        run: rush lint
       - name: Run Tests
-        working-directory: ./packages/neon-dappkit/
-        run: node ../../common/scripts/install-run-rushx.js test
+        run: cd packages/neon-dappkit && pnpm test
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
@@ -41,7 +44,7 @@ jobs:
       - name: Check Code Coverage
         continue-on-error: true
         working-directory: ./packages/neon-dappkit/
-        run: node ../../common/scripts/install-run-rushx.js coverage
+        run: pnpm coverage
       - name: Upload Coverage Summary
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
close #49 

# Summary
Adding lint verification to Github Workflow.
~~Also changed the old commands to use the recommended ones from the documentation:~~
~~https://rushjs.io/pages/maintainer/enabling_ci_builds/#install-run-rushjs-for-bootstrapping-rush~~

> Using install-run-rush.js caused some problems when trying to run the code coverage command